### PR TITLE
Add dalink.to sponsor link as first custom funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://boosty.to/0xffff']
+custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']


### PR DESCRIPTION
### Motivation
- Добавить альтернативный способ спонсирования и сделать так, чтобы ссылка отображалась первой в списке спонсоров на GitHub.

### Description
- Обновлён файл `./.github/FUNDING.yml`: в секцию `custom` добавлена ссылка `https://dalink.to/b4tman1` и размещена первой.

### Testing
- Выполнены автоматические проверки: `cat .github/FUNDING.yml`, `git status --short`, `git log -1 --oneline`, все команды отработали успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ddf68168832e81d37e829f438ad7)